### PR TITLE
Standardize Pluralization of Branch Names

### DIFF
--- a/git/README.md
+++ b/git/README.md
@@ -40,8 +40,8 @@ Another benefit is it lends itself to [this type of organization](https://docs.m
 > - `users/username/description`
 > - `users/username/workitem`
 > - `bugfix/description`
-> - `features/feature-name`
-> - `features/feature-area/feature-name`
+> - `feature/feature-name`
+> - `feature/feature-area/feature-name`
 > - `hotfix/description`
 
 ### Rebase frequently to incorporate upstream changes


### PR DESCRIPTION
The recommended branch prefixes of `bugfix` and `feature` were sometimes pluralized in this document, and sometimes not. This commit standardizes them to singular.