### PR TITLE
Creating a Handlebars guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Conventions, processes and notes about how we do things.
 - **[JavaScript Guide](./javascript/)**
 - **[Design Guide](./design/)**
 - **[Git Guide](./git/)**
+- **[Handlebars Guide](./handlebars)**
 - **[Today I Learned](./til/)**
 - **[Setup npm Publish](./npm)**

--- a/handlebars/README.md
+++ b/handlebars/README.md
@@ -3,5 +3,3 @@
 ## Handlebars files with Markdown frontmatter get improperly indented in VSCode
 
 If you use Visual Studio Code and edit a handlebars file with markdown frontmatter (as you'll commonly find in our pattern libraries), and you have `formatOnSave` enabled, you may find that the frontmatter is improperly indented. You can fix this by setting `html.format.indentHandlebars` to `true`.
-
-[Details in this Slack thread](https://cloudfour.slack.com/archives/CF2KSB7SP/p1551738096034700)

--- a/handlebars/README.md
+++ b/handlebars/README.md
@@ -1,0 +1,7 @@
+# Handlebars Guide
+
+## Handlebars files with Markdown frontmatter get improperly indented in VSCode
+
+If you use Visual Studio Code and edit a handlebars file with markdown frontmatter (as you'll commonly find in our pattern libraries), and you have `formatOnSave` enabled, you may find that the frontmatter is improperly indented. You can fix this by setting `html.format.indentHandlebars` to `true`.
+
+[Details in this Slack thread](https://cloudfour.slack.com/archives/CF2KSB7SP/p1551738096034700)


### PR DESCRIPTION
This commit adds a handlebars guide, and as the first entry, documents a small VScode problem we encountered while working on the LinkedIn pattern library.