### PR TITLE
Add Vue Style Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Conventions, processes and notes about how we do things.
 - **[General Coding Conventions](./coding/)**
 - **[CSS Guide](./css/)**
 - **[JavaScript Guide](./javascript/)**
+    - [Vue Guide](./javascript/vue)
 - **[Design Guide](./design/)**
 - **[Git Guide](./git/)**
 - **[Today I Learned](./til/)**

--- a/javascript/vue/README.md
+++ b/javascript/vue/README.md
@@ -1,0 +1,9 @@
+# Vue Guide
+
+> TODO: add style guide
+
+Until then please refer to these guides:
+
+* [Official Vue Style Guide](https://vuejs.org/v2/style-guide/)
+* [Deverus Vue Style Guide](https://gist.github.com/brianboyko/91fdfb492071e743e389d84eee002342)
+    * [Erik reviews the Deverus Style Guide](https://www.youtube.com/watch?v=38XnZ3EJqYQ)


### PR DESCRIPTION
Vue has it's own set of best practices separate from JS code conventions, and I think it'd be worth having a guide page. Even it for now, it just links to these external guides.