### PR TITLE
Add Blog Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Conventions, processes and notes about how we do things.
 - **[JavaScript Guide](./javascript/)**
     - [Vue Guide](./javascript/vue)
 - **[Design Guide](./design/)**
+- **[Blog Guide](./blog)**
 - **[Git Guide](./git/)**
-- **[Today I Learned](./til/)**
-- **[Setup npm Publish](./npm)**
+- **[npm Guide](./npm)**
 - **[Open Source Guide](./opensource)**
 - **[Rituals Guide](./rituals)**
+- **[Today I Learned](./til/)**

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,6 +1,6 @@
 # Cloud Four Blog Guide
 
-![Captain America sitting on a backwards chair](https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580506044/america_obfr70.jpg)
+<p align="center"><img alt="Captain America sitting on a backwards chair" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_800/v1580506044/america_obfr70.jpg" width="400" /></p>
 
 So you've decided to write for the Cloud Four blog… Congratulations! There are a few things you may want to know about how our blog works:
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -4,11 +4,13 @@
 
 So you've decided to write for the Cloud Four blog… Congratulations! There are a few things you may want to know about how our blog works:
 
-## WordPress Shortcodes
+## Post Excerpt
 
-We have a small collection of useful shortcodes to apply design patterns:
+Don't miss the "Excerpt" field at the bottom of the post editing UI. By crafting a short excerpt here, it will be displayed on the post listing pages and used for social media posts. If you don't set one explicitly, one will be created using the first few sentences of your post.
 
-## Utility Classes
+## WordPress Shortcodes & Classes
+
+In addition to standard Markdown, we have a small collection of [useful shortcodes and classes](patterns.md) to apply design patterns.
 
 For a complete list of available utility classes, visit the [Cloud Four Pattern Library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,3 +1,65 @@
 # Cloud Four Blog Guide
 
 coming soon
+
+## Previewing
+
+TODO: expand and clarify
+
+There are two preview features. One lets you share previews with unauthenticated users. The other is preview for authenticated users.
+
+Sometimes the preview for unauthenticated users can get stuck or cached. The way to get it to uncache is to uncheck the preview box and then check it again.
+
+## Publication Time
+
+Jason's favorite time is 8:30 AM Pacific Time. Before lunch on East Coast, but late enough to be what people on West Coast see it first thing when they arrive in office.
+
+## Comments & Pingbacks
+
+We don’t have a formal policy on comment approval, but here’s Jason's general guideline:
+
+- Let the author approve comments so they have the opportunity to process and respond if they want to.
+- Replying to comments is up to the author. If they contribute to understanding and there is nothing else to add, don’t feel compelled to respond.
+- Delete comments that are spam, troll, or jerk-like behavior.
+
+### Pingbacks
+
+Don't approve pingbacks. We keep the featured enabled so we can see if websites link to us, but there's not very much review in displaying them on the site, and we don't optimize for them in our design.
+
+### Advice from Jason:
+
+> Despite the fact that we ask people to be kind, courteous and constructive when they submit comments on our site, when articles reach a larger audience, we will inevitably end up some with comments that start to inch into an unkind territory. It can be hard to tell how to respond. If they are blatant jerks, I’ll simply delete their comment—you don’t get to come into our house and tear the place up.
+
+> Sometimes with a comment [like this one](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/#comment-5880), I’m pretty sure the author is being a jerk in the second paragraph, but isn’t being direct about it. I usually sit on a response for awhile and only approve the comment when I’m ready to respond in a calm manner. In this case, I decided to ignore the sarcasm and treat the question seriously. [Here's another example](https://cloudfour.com/thinks/first-thing-you-should-do-to-optimize-your-desktop-site-for-mobile/#comment-690).
+
+## Translation Requests
+
+We have received requests to translate our articles in the past, but don't have a set answer.
+
+[Tyler's instinct](https://cloudfour.slack.com/archives/C0L9UQCTU/p1571268050000100) was to say "yes," given that we still get credit, and the link is included, but you should check that the translator has done a respectful job in the past.
+
+## Motivation
+
+[Don't Feel Like an Expert? Share Anyway.](https://medium.com/@sara_ann_marie/dont-feel-like-an-expert-share-anyway-661f2f8cd038)
+
+> Too many of the most interesting voices in tech and design talk themselves out of writing or speaking about their work—because they don’t think they have enough experience. But you don’t have to wait for “enough“ (whatever that means). Here’s how to find what’s special about your perspective right now—wherever you are in your career.
+
+[Advice for Technical Writing](https://css-tricks.com/advice-for-technical-writing/)
+
+> In advance of a recent podcast with the incredible technical writer and Smashing Magazine editor-in-chief Rachel Andrew, I gathered up a bunch of thoughts and references on the subject of technical writing. So many smart people have said a lot of smart things over the years that I thought I'd round up some of my favorite advice and sprinkle in my own experiences, as someone who has also done his fair share of technical writing and editing.
+
+[Avoid the Word "Just"](https://bradfrost.com/blog/post/just/)
+
+> “Just” makes me feel like an idiot. “Just” presumes I come from a specific background, studied certain courses in university, am fluent in certain technologies, and have read all the right books, articles, and resources. “Just” is a dangerous word.
+
+[Keep Code Samples Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
+
+> When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
+
+[Know Your Audience](https://cloudfour.slack.com/archives/C0L9UQCTU/p1572999313002300)
+
+The full thread is worth reading, but TL;DR: When deciding how much context to include in a technical article, it's good to have a clear picture of your intended audience. Tyler says most of his articles are either written for himself in the past, or for our customers. If some context is necessary but isn't really the crux of your article, you can link to something that gets the reader up to speed for your point.
+
+[Write a Hulk Summary](https://chriscoyier.net/2020/01/23/the-hulk-summary/)
+
+> … channel your inner Hulk voice … and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.

--- a/blog/README.md
+++ b/blog/README.md
@@ -4,9 +4,13 @@
 
 So you've decided to write for the Cloud Four blog… Congratulations! There are a few things you may want to know about how our blog works:
 
-## Post Excerpt
+## Post Excerpt Field
 
 Don't miss the "Excerpt" field at the bottom of the post editing UI. By crafting a short excerpt here, it will be displayed on the post listing pages and used for social media posts. If you don't set one explicitly, one will be created using the first few sentences of your post.
+
+## Featured Image Field
+
+Similarly, don't forget the "Featured Image" field in the sidebar. If you set an image here, it will be used for social media. This image is not displayed in the post content, however, so if you want to use it as a big image at the top of your post, you'll have to do that AND set the featured image.
 
 ## WordPress Shortcodes & Classes
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -36,13 +36,11 @@ We don’t have a formal policy on comment approval, but here’s Jason's genera
 
 ### Advice from Jason:
 
-> Despite the fact that we ask people to be kind, courteous and constructive when they submit comments on our site, when articles reach a larger audience, we will inevitably end up some with comments that start to inch into an unkind territory. It can be hard to tell how to respond. If they are blatant jerks, I’ll simply delete their comment—you don’t get to come into our house and tear the place up.
-
-> Sometimes with a comment [like this one](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/#comment-5880), I’ll decide to ignore the sarcasm and treat the question seriously. [Here's another example](https://cloudfour.com/thinks/first-thing-you-should-do-to-optimize-your-desktop-site-for-mobile/#comment-690).
+> Despite the fact that we ask people to be kind, courteous and constructive when they submit comments on our site, when articles reach a larger audience, we will inevitably end up some with comments that start to inch into an unkind territory. It can be hard to tell how to respond. If they are blatant jerks, I’ll simply delete their comment—you don’t get to come into our house and tear the place up. Sometimes with an obviously snarky comment, I’ll ignore the sarcasm and respond to the question as if it was asked in earnest.
 
 ### Pingbacks
 
-Don't approve pingbacks. We keep the featured enabled so we can see if websites link to us, but there's not very much review in displaying them on the site, and we don't optimize for them in our design.
+Don't approve pingbacks. We keep the feature enabled so we can see if websites link to us, but there's not very much review in displaying them on the site, and we don't optimize for them in our design.
 
 ## Translation Requests
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,0 +1,3 @@
+# Cloud Four Blog Guide
+
+coming soon

--- a/blog/README.md
+++ b/blog/README.md
@@ -58,6 +58,16 @@ We have received requests to translate our articles in the past, but don't have 
 
 > “Just” makes me feel like an idiot. “Just” presumes I come from a specific background, studied certain courses in university, am fluent in certain technologies, and have read all the right books, articles, and resources. “Just” is a dangerous word.
 
+[Words To Avoid in Educational Writing](https://css-tricks.com/words-avoid-educational-writing/)
+
+> I'm no English major, but as a writer and consumer of loads of educational (mostly tech) writing, I've come to notice a number of words and phrases that come up fairly often and don't add anything to the writing. In fact, they might detract from it.
+
+> Obviously; Basically; Simply; Of course; Clearly; Just; Everyone knows; However; So; Easy;
+
+[Plain Language Is for Everyone, Even Experts](https://www.nngroup.com/articles/plain-language-experts/)
+
+> Professionals want clear, concise information devoid of unnecessary jargon or complex terms. Plain language benefits both consumers and organizations.
+
 [Keep Code Samples Short & Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
 
 > When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.

--- a/blog/README.md
+++ b/blog/README.md
@@ -26,7 +26,7 @@ We don’t have a formal policy on comment approval, but here’s Jason's genera
 
 > Despite the fact that we ask people to be kind, courteous and constructive when they submit comments on our site, when articles reach a larger audience, we will inevitably end up some with comments that start to inch into an unkind territory. It can be hard to tell how to respond. If they are blatant jerks, I’ll simply delete their comment—you don’t get to come into our house and tear the place up.
 
-> Sometimes with a comment [like this one](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/#comment-5880), I’m pretty sure the author is being a jerk in the second paragraph, but isn’t being direct about it. I usually sit on a response for awhile and only approve the comment when I’m ready to respond in a calm manner. In this case, I decided to ignore the sarcasm and treat the question seriously. [Here's another example](https://cloudfour.com/thinks/first-thing-you-should-do-to-optimize-your-desktop-site-for-mobile/#comment-690).
+> Sometimes with a comment [like this one](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/#comment-5880), I’ll decide to ignore the sarcasm and treat the question seriously. [Here's another example](https://cloudfour.com/thinks/first-thing-you-should-do-to-optimize-your-desktop-site-for-mobile/#comment-690).
 
 ### Pingbacks
 
@@ -34,9 +34,7 @@ Don't approve pingbacks. We keep the featured enabled so we can see if websites 
 
 ## Translation Requests
 
-We have received requests to translate our articles in the past, but don't have a set answer.
-
-[Tyler's instinct](https://cloudfour.slack.com/archives/C0L9UQCTU/p1571268050000100) was to say "yes," given that we still get credit, and the link is included, but you should check that the translator has done a respectful job in the past.
+We have received requests to translate our articles in the past, but don't have a set answer. We'll considering saying "yes," if we still get credit, a link back to our site is clearly included, and they have a demonstrable track record of respectful translations.
 
 ## Writing Advice
 
@@ -56,7 +54,7 @@ We have received requests to translate our articles in the past, but don't have 
 
 > When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
 
-[Know Your Audience](https://cloudfour.slack.com/archives/C0L9UQCTU/p1572999313002300)
+[Know Your Audience](https://cloudfour.slack.com/archives/C0L9UQCTU/p1572999313002300) (internal Slack thread)
 
 The full thread is worth reading, but TL;DR: When deciding how much context to include in a technical article, it's good to have a clear picture of your intended audience. Tyler says most of his articles are either written for himself in the past, or for our customers. If some context is necessary but isn't really the crux of your article, you can link to something that gets the reader up to speed for your point.
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -54,10 +54,6 @@ We have received requests to translate our articles in the past, but don't have 
 
 > When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
 
-[Know Your Audience](https://cloudfour.slack.com/archives/C0L9UQCTU/p1572999313002300) (internal Slack thread)
-
-The full thread is worth reading, but TL;DR: When deciding how much context to include in a technical article, it's good to have a clear picture of your intended audience. Tyler says most of his articles are either written for himself in the past, or for our customers. If some context is necessary but isn't really the crux of your article, you can link to something that gets the reader up to speed for your point.
-
 [Write a Hulk Summary](https://chriscoyier.net/2020/01/23/the-hulk-summary/)
 
 > Channel your inner Hulk voice and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,14 +1,22 @@
 # Cloud Four Blog Guide
 
-coming soon
+![Captain America sitting on a backwards chair](https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580506044/america_obfr70.jpg)
+
+So you've decided to write for the Cloud Four blog… Congratulations! There are a few things you may want to know about how our blog works:
+
+## WordPress Shortcodes
+
+We have a small collection of useful shortcodes to apply design patterns:
+
+## Utility Classes
+
+For a complete list of available utility classes, visit the [Cloud Four Pattern Library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
 
 ## Previewing
 
-TODO: expand and clarify
+Note that our blog has two preview features. The "Preview" button only works for authenticated users. The "Enable Public Preview" checkbox will give you a public URL to share with unauthenticated users.
 
-There are two preview features. One lets you share previews with unauthenticated users. The other is preview for authenticated users.
-
-Sometimes the preview for unauthenticated users can get stuck or cached. The way to get it to uncache is to uncheck the preview box and then check it again.
+Sometimes the public preview can get stuck or cached. To reset, just uncheck the preview box and check it again.
 
 ## Publication Time
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -38,7 +38,7 @@ We have received requests to translate our articles in the past, but don't have 
 
 [Tyler's instinct](https://cloudfour.slack.com/archives/C0L9UQCTU/p1571268050000100) was to say "yes," given that we still get credit, and the link is included, but you should check that the translator has done a respectful job in the past.
 
-## Motivation
+## Writing Advice
 
 [Don't Feel Like an Expert? Share Anyway.](https://medium.com/@sara_ann_marie/dont-feel-like-an-expert-share-anyway-661f2f8cd038)
 
@@ -52,7 +52,7 @@ We have received requests to translate our articles in the past, but don't have 
 
 > “Just” makes me feel like an idiot. “Just” presumes I come from a specific background, studied certain courses in university, am fluent in certain technologies, and have read all the right books, articles, and resources. “Just” is a dangerous word.
 
-[Keep Code Samples Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
+[Keep Code Samples Short & Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
 
 > When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
 
@@ -62,4 +62,6 @@ The full thread is worth reading, but TL;DR: When deciding how much context to i
 
 [Write a Hulk Summary](https://chriscoyier.net/2020/01/23/the-hulk-summary/)
 
-> … channel your inner Hulk voice … and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.
+> Channel your inner Hulk voice and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.
+
+> WRITING IS HARD; YOU THINK TOO MUCH! WE HAVE A SOLUTION; THE HULK SUMMARY!

--- a/blog/README.md
+++ b/blog/README.md
@@ -14,7 +14,7 @@ Similarly, don't forget the "Featured Image" field in the sidebar. If you set an
 
 ## WordPress Shortcodes & Classes
 
-In addition to standard Markdown, we have a small collection of [useful shortcodes and classes](patterns.md) to apply design patterns from our [pattern library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
+We have a small collection of [useful shortcodes and classes](patterns.md) to apply design patterns from our [pattern library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
 
 ## Previewing
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -22,15 +22,15 @@ We don’t have a formal policy on comment approval, but here’s Jason's genera
 - Replying to comments is up to the author. If they contribute to understanding and there is nothing else to add, don’t feel compelled to respond.
 - Delete comments that are spam, troll, or jerk-like behavior.
 
-### Pingbacks
-
-Don't approve pingbacks. We keep the featured enabled so we can see if websites link to us, but there's not very much review in displaying them on the site, and we don't optimize for them in our design.
-
 ### Advice from Jason:
 
 > Despite the fact that we ask people to be kind, courteous and constructive when they submit comments on our site, when articles reach a larger audience, we will inevitably end up some with comments that start to inch into an unkind territory. It can be hard to tell how to respond. If they are blatant jerks, I’ll simply delete their comment—you don’t get to come into our house and tear the place up.
 
 > Sometimes with a comment [like this one](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/#comment-5880), I’m pretty sure the author is being a jerk in the second paragraph, but isn’t being direct about it. I usually sit on a response for awhile and only approve the comment when I’m ready to respond in a calm manner. In this case, I decided to ignore the sarcasm and treat the question seriously. [Here's another example](https://cloudfour.com/thinks/first-thing-you-should-do-to-optimize-your-desktop-site-for-mobile/#comment-690).
+
+### Pingbacks
+
+Don't approve pingbacks. We keep the featured enabled so we can see if websites link to us, but there's not very much review in displaying them on the site, and we don't optimize for them in our design.
 
 ## Translation Requests
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -14,9 +14,7 @@ Similarly, don't forget the "Featured Image" field in the sidebar. If you set an
 
 ## WordPress Shortcodes & Classes
 
-In addition to standard Markdown, we have a small collection of [useful shortcodes and classes](patterns.md) to apply design patterns.
-
-For a complete list of available utility classes, visit the [Cloud Four Pattern Library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
+In addition to standard Markdown, we have a small collection of [useful shortcodes and classes](patterns.md) to apply design patterns from our [pattern library](https://cloudfour-patterns.netlify.com/patterns/utilities.html).
 
 ## Previewing
 

--- a/blog/README.md
+++ b/blog/README.md
@@ -52,34 +52,34 @@ We have received requests to translate our articles in the past, but don't have 
 
 ## Writing Advice
 
-[Don't Feel Like an Expert? Share Anyway.](https://medium.com/@sara_ann_marie/dont-feel-like-an-expert-share-anyway-661f2f8cd038)
+- [Don't Feel Like an Expert? Share Anyway.](https://medium.com/@sara_ann_marie/dont-feel-like-an-expert-share-anyway-661f2f8cd038)
 
-> Too many of the most interesting voices in tech and design talk themselves out of writing or speaking about their work—because they don’t think they have enough experience. But you don’t have to wait for “enough“ (whatever that means). Here’s how to find what’s special about your perspective right now—wherever you are in your career.
+  > Too many of the most interesting voices in tech and design talk themselves out of writing or speaking about their work—because they don’t think they have enough experience. But you don’t have to wait for “enough“ (whatever that means). Here’s how to find what’s special about your perspective right now—wherever you are in your career.
 
-[Advice for Technical Writing](https://css-tricks.com/advice-for-technical-writing/)
+- [Advice for Technical Writing](https://css-tricks.com/advice-for-technical-writing/)
 
-> In advance of a recent podcast with the incredible technical writer and Smashing Magazine editor-in-chief Rachel Andrew, I gathered up a bunch of thoughts and references on the subject of technical writing. So many smart people have said a lot of smart things over the years that I thought I'd round up some of my favorite advice and sprinkle in my own experiences, as someone who has also done his fair share of technical writing and editing.
+  > In advance of a recent podcast with the incredible technical writer and Smashing Magazine editor-in-chief Rachel Andrew, I gathered up a bunch of thoughts and references on the subject of technical writing. So many smart people have said a lot of smart things over the years that I thought I'd round up some of my favorite advice and sprinkle in my own experiences, as someone who has also done his fair share of technical writing and editing.
 
-[Avoid the Word "Just"](https://bradfrost.com/blog/post/just/)
+- [Avoid the Word "Just"](https://bradfrost.com/blog/post/just/)
 
-> “Just” makes me feel like an idiot. “Just” presumes I come from a specific background, studied certain courses in university, am fluent in certain technologies, and have read all the right books, articles, and resources. “Just” is a dangerous word.
+  > “Just” makes me feel like an idiot. “Just” presumes I come from a specific background, studied certain courses in university, am fluent in certain technologies, and have read all the right books, articles, and resources. “Just” is a dangerous word.
 
-[Words To Avoid in Educational Writing](https://css-tricks.com/words-avoid-educational-writing/)
+- [Words To Avoid in Educational Writing](https://css-tricks.com/words-avoid-educational-writing/)
 
-> I'm no English major, but as a writer and consumer of loads of educational (mostly tech) writing, I've come to notice a number of words and phrases that come up fairly often and don't add anything to the writing. In fact, they might detract from it.
+  > I'm no English major, but as a writer and consumer of loads of educational (mostly tech) writing, I've come to notice a number of words and phrases that come up fairly often and don't add anything to the writing. In fact, they might detract from it.
 
-> Obviously; Basically; Simply; Of course; Clearly; Just; Everyone knows; However; So; Easy;
+  > Obviously; Basically; Simply; Of course; Clearly; Just; Everyone knows; However; So; Easy;
 
-[Plain Language Is for Everyone, Even Experts](https://www.nngroup.com/articles/plain-language-experts/)
+- [Plain Language Is for Everyone, Even Experts](https://www.nngroup.com/articles/plain-language-experts/)
 
-> Professionals want clear, concise information devoid of unnecessary jargon or complex terms. Plain language benefits both consumers and organizations.
+  > Professionals want clear, concise information devoid of unnecessary jargon or complex terms. Plain language benefits both consumers and organizations.
 
-[Keep Code Samples Short & Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
+- [Keep Code Samples Short & Relevant](https://twitter.com/sarah_edo/status/1106631555693187073)
 
-> When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
+  > When writing technical blog posts, please take care that the code samples in the article aren't long. In my opinion, the post shouldn't be the full repo. Highlight the specific parts of interest, and peel away boilerplate so people can read less and learn more. Then, if needed, link to a more complete code example on [CodePen](https://codepen.io/), [JSBin](https://jsbin.com/), or something similar.
 
-[Write a Hulk Summary](https://chriscoyier.net/2020/01/23/the-hulk-summary/)
+- [Write a Hulk Summary](https://chriscoyier.net/2020/01/23/the-hulk-summary/)
 
-> Channel your inner Hulk voice and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.
+  > Channel your inner Hulk voice and use it to describe whatever you need to get writing on. Hammer down that shift key (caps lock is a cop-out) and type max 4 words for each bullet to capture the core sentiment of what you’re arguing.
 
-> WRITING IS HARD; YOU THINK TOO MUCH! WE HAVE A SOLUTION; THE HULK SUMMARY!
+  > WRITING IS HARD; YOU THINK TOO MUCH! WE HAVE A SOLUTION; THE HULK SUMMARY!

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -4,15 +4,17 @@ In addition to [Markdown](https://en.support.wordpress.com/markdown-quick-refere
 
 ## Box Shortcode
 
+<p align="center"><a href="https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/"><img alt="Box Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/box.png" /></a></p>
+
 The Box shortcode will create a [Post Intro](https://cloudfour-patterns.netlify.com/patterns/combos/blog.html#post-intro). It will strip any line breaks from the text.
 
 ```html
 [c4box]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.[/c4box]
 ```
 
-- [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
-
 #### Grow Modifier
+
+<p align="center"><a href="https://cloudfour.com/thinks/mood-boards/"><img alt="Box Grow Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/box-grow.png" /></a></p>
 
 The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
 
@@ -22,9 +24,9 @@ The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.ne
 
 You can use `grow=0` to keep the text the same size as the rest of the post, which is useful for a sort of alert box.
 
-- [Example](https://cloudfour.com/thinks/mood-boards/)
-
 ## Footnotes
+
+<p align="center"><a href="https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/"><img alt="Footnotes Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/footnotes.png" /></a></p>
 
 This is actually a feature of WordPress's version of [Markdown Extra](https://en.support.wordpress.com/markdown-quick-reference/).
 
@@ -38,9 +40,9 @@ I have more [^1] to say up here.
 
 Footnotes marked up this way will be added to the bottom of the post with a link back to the original reference.
 
-- [Example](https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/)
-
 ## Figure Shortcode
+
+<p align="center"><a href="https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/"><img alt="Figure Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/figure.png" /></a></p>
 
 The Figure shortcode will create a [Figure](https://cloudfour-patterns.netlify.com/patterns/components/figure.html), with an optional caption and class.
 
@@ -52,19 +54,9 @@ The Figure shortcode will create a [Figure](https://cloudfour-patterns.netlify.c
 
 Note the optional use of the `u-borderSm` utility class to add a light border to the image. Images with a white background may benefit from a border.
 
-- [Example](https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/)
-
-#### Shrink Modifier
-
-The Grow modifier will add a [`u-textShrinkX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
-
-```html
-[c4figure caption="A caption with very small text" shrink=3]
-<img src="https://cloudfour.com/wp-content/uploads/2016/11/cloudfour-offline-banner-400.png" class="u-borderSm">
-[/c4figure]
-```
-
 ## FlexEmbed Shortcode
+
+<p align="center"><a href="https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/"><img alt="Flex Embed Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/flexembed.png" /></a></p>
 
 The FlexEmbed shortcode create a [Flex Embed](https://cloudfour-patterns.netlify.com/patterns/components/flex-embed.html), used to make an embed resize responsively while retaining its aspect ratio..
 
@@ -73,8 +65,6 @@ The FlexEmbed shortcode create a [Flex Embed](https://cloudfour-patterns.netlify
 <iframe width="420" height="315" src="https://www.youtube.com/embed/Nx64_N4AA04" frameborder="0" allowfullscreen></iframe>
 [/c4flexembed]
 ```
-
-- [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
 
 #### Ratio Modifier
 
@@ -96,9 +86,9 @@ Passing the `nowrap` modifier will prevent the embedded content from being wrapp
 [/c4flexembed]
 ```
 
-- [Example](https://cloudfour.com/thinks/feeling-sassy-again/)
-
 #### Combining with Figure
+
+<p align="center"><a href="https://cloudfour.com/thinks/unsolved-problems/"><img alt="Flex Embed with Caption Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/flexembed-caption.png" /></a></p>
 
 You can use `c4flexembed` inside `c4figure` to add a caption to your embedded content.
 
@@ -110,11 +100,11 @@ You can use `c4flexembed` inside `c4figure` to add a caption to your embedded co
 [/c4figure]
 ```
 
-- [Example](https://cloudfour.com/thinks/unsolved-problems/)
-
 ## Image Alignment
 
 #### Featured Image
+
+<p align="center"><a href="https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/"><img alt="Featured Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/featured-image.png" /></a></p>
 
 A featured image is pulled outside the content column, but isn't quite full-bleed. We accomplish this using [`u-pullSidesX` utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#space).
 
@@ -128,9 +118,9 @@ A featured image is pulled outside the content column, but isn't quite full-blee
 
 Here, the combination of `u-pullSides1 u-md-pullSides6` will pull the image just outside the content container on small screens, and quite a bit more on medium and larger screens.
 
-- [Example](https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/)
-
 #### Full-Bleed Image
+
+<p align="center"><a href="https://cloudfour.com/thinks/progressive-web-apps-book-now-available/"><img alt="Full-Bleed Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/full-bleed-image.png" /></a></p>
 
 If you have an image you really want to showcase, try using the `u-release` class to make it full-bleed. Be aware this works best with images that are much wider than they are tall, otherwise users with very wide browsers may find the image fills the entire screen.
 
@@ -142,9 +132,9 @@ If you have an image you really want to showcase, try using the `u-release` clas
 </div>
 ```
 
-- [Example](https://cloudfour.com/thinks/progressive-web-apps-book-now-available/)
-
 #### Float Left/Right Image
+
+<p align="center"><a href="https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/"><img alt="Floated Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/float-right-image.png" /></a></p>
 
 Use a combination of [sizing utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#size) and [layout utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#layout) to scale and image and float it left or right.
 
@@ -157,5 +147,3 @@ Use a combination of [sizing utility classes](https://cloudfour-patterns.netlify
 ```
 
 Here, `u-sm-size1of2` will keep the image sized to 50% of the content column, `u-sm-floatRight` will float the image to the right on small screens and larger (but not very small screens). `u-sm-spaceLeft1` ensures there's margin on the image so text doesn't run up against it, and `u-md-pullRight6` will pull the floated image slightly outside the content container on medium and larger screens.
-
-- [Example](https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/)

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -72,7 +72,7 @@ The FlexEmbed shortcode create a [Flex Embed](https://cloudfour-patterns.netlify
 
 #### Ratio Modifier
 
-You can manually choose the aspect ratio of the embed by setting the `ratio` attribute to either `1by1, `2by1`, `3by1`, or `4by3`. You don't need to specify `16by9`, as that's the default.
+You can manually choose the aspect ratio of the embed by setting the `ratio` attribute to either `1by1`, `2by1`, `3by1`, or `4by3`. You don't need to specify `16by9`, as that's the default.
 
 ```html
 [c4flexembed ratio="1by1"]

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -1,6 +1,6 @@
 # WordPress Shortcodes & Classes
 
-In addition to standard Markdown, we have a small collection of useful shortcodes and classes to apply design patterns:
+In addition to [Markdown](https://en.support.wordpress.com/markdown-quick-reference/), we have a small collection of useful shortcodes and classes to apply design patterns:
 
 ## Box Shortcode
 
@@ -23,6 +23,22 @@ The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.ne
 You can use `grow=0` to keep the text the same size as the rest of the post, which is useful for a sort of alert box.
 
 - [Example](https://cloudfour.com/thinks/mood-boards/)
+
+## Footnotes
+
+This is actually a feature of WordPress's version of [Markdown Extra](https://en.support.wordpress.com/markdown-quick-reference/).
+
+```md
+I have more [^1] to say up here.
+
+(other post content)
+
+[^1]: To say down here.
+```
+
+Footnotes marked up this way will be added to the bottom of the post with a link back to the original reference.
+
+- [Example](https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/)
 
 ## Figure Shortcode
 

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -9,7 +9,9 @@ In addition to [Markdown](https://en.support.wordpress.com/markdown-quick-refere
 The Box shortcode will create a [Post Intro](https://cloudfour-patterns.netlify.com/patterns/combos/blog.html#post-intro). It will strip any line breaks from the text.
 
 ```html
-[c4box]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.[/c4box]
+[c4box]
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+[/c4box]
 ```
 
 #### Grow Modifier
@@ -19,7 +21,9 @@ The Box shortcode will create a [Post Intro](https://cloudfour-patterns.netlify.
 The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
 
 ```html
-[c4box grow=2]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.[/c4box]
+[c4box grow=2]
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+[/c4box]
 ```
 
 You can use `grow=0` to keep the text the same size as the rest of the post, which is useful for a sort of alert box.

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -1,0 +1,145 @@
+# WordPress Shortcodes & Classes
+
+In addition to standard Markdown, we have a small collection of useful shortcodes and classes to apply design patterns:
+
+## Box Shortcode
+
+The Box shortcode will create a [Post Intro](https://cloudfour-patterns.netlify.com/patterns/combos/blog.html#post-intro). It will strip any line breaks from the text.
+
+```html
+[c4box]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.[/c4box]
+```
+
+- [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
+
+### Grow Modifier
+
+The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
+
+```html
+[c4box grow=2]Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.[/c4box]
+```
+
+You can use `grow=0` to keep the text the same size as the rest of the post, which is useful for a sort of alert box.
+
+- [Example](https://cloudfour.com/thinks/mood-boards/)
+
+## Figure Shortcode
+
+The Figure shortcode will create a [Figure](https://cloudfour-patterns.netlify.com/patterns/components/figure.html), with an optional caption and class.
+
+```html
+[c4figure caption="Our offline notification banner." class="example"]
+<img src="https://cloudfour.com/wp-content/uploads/2016/11/cloudfour-offline-banner-400.png" class="u-borderSm">
+[/c4figure]
+```
+
+Note the optional use of the `u-borderSm` utility class to add a light border to the image. Images with a white background may benefit from a border.
+
+- [Example](https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/)
+
+### Shrink Modifier
+
+The Grow modifier will add a [`u-textShrinkX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
+
+```html
+[c4figure caption="A caption with very small text" shrink=3]
+<img src="https://cloudfour.com/wp-content/uploads/2016/11/cloudfour-offline-banner-400.png" class="u-borderSm">
+[/c4figure]
+```
+
+## FlexEmbed Shortcode
+
+The FlexEmbed shortcode create a [Flex Embed](https://cloudfour-patterns.netlify.com/patterns/components/flex-embed.html), used to make an embed resize responsively while retaining its aspect ratio..
+
+```html
+[c4flexembed]
+<iframe width="420" height="315" src="https://www.youtube.com/embed/Nx64_N4AA04" frameborder="0" allowfullscreen></iframe>
+[/c4flexembed]
+```
+
+- [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
+
+### Ratio Modifier
+
+You can manually choose the aspect ratio of the embed by setting the `ratio` attribute to either `1by1, `2by1`, `3by1`, or `4by3`. You don't need to specify `16by9`, as that's the default.
+
+```html
+[c4flexembed ratio="1by1"]
+<iframe width="420" height="315" src="https://www.youtube.com/embed/Nx64_N4AA04" frameborder="0" allowfullscreen></iframe>
+[/c4flexembed]
+```
+
+### No Wrap Modifier
+
+Passing the `nowrap` modifier will prevent the embedded content from being wrapped in `<div class="FlexEmbed-content">…</div>`. It's useful if you're manually adding the class to your embed.
+
+```html
+[c4flexembed nowrap=true]
+<iframe class="FlexEmbed-content" width="420" height="315" src="https://www.youtube.com/embed/Nx64_N4AA04" frameborder="0" allowfullscreen></iframe>
+[/c4flexembed]
+```
+
+- [Example](https://cloudfour.com/thinks/feeling-sassy-again/)
+
+### Combining with Figure
+
+You can use `c4flexembed` inside `c4figure` to add a caption to your embedded content.
+
+```html
+[c4figure caption="Val Head's animation talk from <a href='https://www.responsivefieldday.com/'>Responsive Field Day</a>"]
+[c4flexembed]
+<iframe width="560" height="315" src="https://www.youtube.com/embed/O1SQ7FOVO_U" frameborder="0" allowfullscreen></iframe>
+[/c4flexembed]
+[/c4figure]
+```
+
+- [Example](https://cloudfour.com/thinks/unsolved-problems/)
+
+## Image Alignment
+
+### Featured Image
+
+A featured image is pulled outside the content column, but isn't quite full-bleed. We accomplish this using [`u-pullSidesX` utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#space).
+
+```html
+<div class="u-pullSides1 u-md-pullSides6">
+[c4figure]
+<img src="https://cloudfour.com/wp-content/uploads/2020/01/wallywood22panel1600.jpg" alt="Wally Wood’s 22 Panels That Always Work" width="1600" height="1215" class="wp-image-5679" />
+[/c4figure]
+</div>
+```
+
+Here, the combination of `u-pullSides1 u-md-pullSides6` will pull the image just outside the content container on small screens, and quite a bit more on medium and larger screens.
+
+- [Example](https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/)
+
+### Full-Bleed Image
+
+If you have an image you really want to showcase, try using the `u-release` class to make it full-bleed. Be aware this works best with images that are much wider than they are tall, otherwise users with very wide browsers may find the image fills the entire screen.
+
+```html
+<div class="u-release">
+[c4figure caption="My book was conference SWAG! It was handed out along with t-shirts and water bottles as attendees entered the conference."]
+<img src="https://cloudfour.com/wp-content/uploads/2018/11/book-swag-at-cds.jpg">
+[/c4figure]
+</div>
+```
+
+- [Example](https://cloudfour.com/thinks/progressive-web-apps-book-now-available/)
+
+### Float Left/Right Image
+
+Use a combination of [sizing utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#size) and [layout utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#layout) to scale and image and float it left or right.
+
+```html
+<div class="u-sm-size1of2 u-sm-floatRight u-sm-spaceLeft1 u-md-pullRight6">
+[c4figure]
+<img src="https://cloudfour.com/wp-content/uploads/2020/01/dd5-cropped.jpg" alt="The cover for Daredevil issue 5, with a caption promoting art by Wally Wood." width="1957" height="2795" class="wp-image-5682" />
+[/c4figure]
+</div>
+```
+
+Here, `u-sm-size1of2` will keep the image sized to 50% of the content column, `u-sm-floatRight` will float the image to the right on small screens and larger (but not very small screens). `u-sm-spaceLeft1` ensures there's margin on the image so text doesn't run up against it, and `u-md-pullRight6` will pull the floated image slightly outside the content container on medium and larger screens.
+
+- [Example](https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/)

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -12,7 +12,7 @@ The Box shortcode will create a [Post Intro](https://cloudfour-patterns.netlify.
 
 - [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
 
-### Grow Modifier
+#### Grow Modifier
 
 The Grow modifier will add a [`u-textGrowX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
 
@@ -38,7 +38,7 @@ Note the optional use of the `u-borderSm` utility class to add a light border to
 
 - [Example](https://cloudfour.com/thinks/hey-hey-cloud-four-is-a-pwa/)
 
-### Shrink Modifier
+#### Shrink Modifier
 
 The Grow modifier will add a [`u-textShrinkX` class](https://cloudfour-patterns.netlify.com/patterns/utilities.html#text) using whatever size you pass in.
 
@@ -60,7 +60,7 @@ The FlexEmbed shortcode create a [Flex Embed](https://cloudfour-patterns.netlify
 
 - [Example](https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/)
 
-### Ratio Modifier
+#### Ratio Modifier
 
 You can manually choose the aspect ratio of the embed by setting the `ratio` attribute to either `1by1, `2by1`, `3by1`, or `4by3`. You don't need to specify `16by9`, as that's the default.
 
@@ -70,7 +70,7 @@ You can manually choose the aspect ratio of the embed by setting the `ratio` att
 [/c4flexembed]
 ```
 
-### No Wrap Modifier
+#### No Wrap Modifier
 
 Passing the `nowrap` modifier will prevent the embedded content from being wrapped in `<div class="FlexEmbed-content">…</div>`. It's useful if you're manually adding the class to your embed.
 
@@ -82,7 +82,7 @@ Passing the `nowrap` modifier will prevent the embedded content from being wrapp
 
 - [Example](https://cloudfour.com/thinks/feeling-sassy-again/)
 
-### Combining with Figure
+#### Combining with Figure
 
 You can use `c4flexembed` inside `c4figure` to add a caption to your embedded content.
 
@@ -98,7 +98,7 @@ You can use `c4flexembed` inside `c4figure` to add a caption to your embedded co
 
 ## Image Alignment
 
-### Featured Image
+#### Featured Image
 
 A featured image is pulled outside the content column, but isn't quite full-bleed. We accomplish this using [`u-pullSidesX` utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#space).
 
@@ -114,7 +114,7 @@ Here, the combination of `u-pullSides1 u-md-pullSides6` will pull the image just
 
 - [Example](https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/)
 
-### Full-Bleed Image
+#### Full-Bleed Image
 
 If you have an image you really want to showcase, try using the `u-release` class to make it full-bleed. Be aware this works best with images that are much wider than they are tall, otherwise users with very wide browsers may find the image fills the entire screen.
 
@@ -128,7 +128,7 @@ If you have an image you really want to showcase, try using the `u-release` clas
 
 - [Example](https://cloudfour.com/thinks/progressive-web-apps-book-now-available/)
 
-### Float Left/Right Image
+#### Float Left/Right Image
 
 Use a combination of [sizing utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#size) and [layout utility classes](https://cloudfour-patterns.netlify.com/patterns/utilities.html#layout) to scale and image and float it left or right.
 

--- a/blog/patterns.md
+++ b/blog/patterns.md
@@ -106,7 +106,7 @@ You can use `c4flexembed` inside `c4figure` to add a caption to your embedded co
 
 ## Image Alignment
 
-#### Featured Image
+### Featured Image
 
 <p align="center"><a href="https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/"><img alt="Featured Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/featured-image.png" /></a></p>
 
@@ -122,7 +122,7 @@ A featured image is pulled outside the content column, but isn't quite full-blee
 
 Here, the combination of `u-pullSides1 u-md-pullSides6` will pull the image just outside the content container on small screens, and quite a bit more on medium and larger screens.
 
-#### Full-Bleed Image
+### Full-Bleed Image
 
 <p align="center"><a href="https://cloudfour.com/thinks/progressive-web-apps-book-now-available/"><img alt="Full-Bleed Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/full-bleed-image.png" /></a></p>
 
@@ -136,7 +136,7 @@ If you have an image you really want to showcase, try using the `u-release` clas
 </div>
 ```
 
-#### Float Left/Right Image
+### Float Left/Right Image
 
 <p align="center"><a href="https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/"><img alt="Floated Image Example" src="https://res.cloudinary.com/cloudfour/image/upload/c_scale,f_auto,q_auto,w_400/v1580512879/blog-patterns/float-right-image.png" /></a></p>
 


### PR DESCRIPTION
This PR adds a new Blog Guide, with a collection of tips shared on our #writing channel over the last year, as well as a list of WordPress shortcodes and common utility class patterns that new writers may not be aware of.