### PR TITLE
Add package.json script names from slack discussion

### DIFF
--- a/package-json-script-names.md
+++ b/package-json-script-names.md
@@ -1,0 +1,28 @@
+# `package.json` Script Names
+
+## General
+
+- `npm run validate`: Runs all tests, type checks, linters, and formatters
+
+## Testing
+
+- `npm run test`: Runs all test runners (Jest and/or Cypress)
+- `npm run test:watch`: Runs all test runners in watch mode
+- `npm run test:jest`: Runs Jest and exits
+- `npm run test:jest:watch`: Runs Jest in watch mode
+- `npm run test:cypress`: Runs Cypress and exits
+- `npm run test:cypress:open`: Open Cypress dashboard
+
+## Linting
+
+- `npm run lint`: Runs all linters and formatters, and fixes any auto-fixable problems
+- `npm run lint:check`: Runs all linters and formatters, and reports problems even if they are auto-fixable
+- `npm run lint:js`
+- `npm run lint:js:check`
+- `npm run lint:css`
+- `npm run lint:css:check`
+
+## Type Checking
+
+- `npm run type`: Runs typechecker
+- `npm run type:watch`: Runs the typechecker in watch mode

--- a/testing/README.md
+++ b/testing/README.md
@@ -11,13 +11,14 @@
 ## Best Practices & Standardization
 
 ### General
-* Organization of `scripts` in package.json:
-	- `test` = runs all unit/integration/E2E tests in headless mode
-	- `test:watch` = same as `test` but with Jest in watch mode
-	- `cypress` = run Cypress with the [Cypress Test Runner](https://docs.cypress.io/guides/guides/command-line.html#cypress-open)
-	- `check-lint` = runs style lint, eslint, prettier
-	- `lint` = same as `check-lint` but writes the changes (`--fix`)
-	- `ci` = run EVERYTHING
+* Organization of testing scripts in `package.json` ([more details](../package-json-script-names.md))
+  * `npm run test`: Runs all test runners (Jest and/or Cypress)
+  * `npm run test:watch`: Runs all test runners in watch mode
+  * `npm run test:jest`: Runs Jest and exits
+  * `npm run test:jest:watch`: Runs Jest in watch mode
+  * `npm run test:cypress`: Runs Cypress and exits
+  * `npm run test:cypress:open`: Open Cypress dashboard
+
 * [Apply the AHA principle](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing). Try to minimize nesting, coupling and over-abstraction. These make tests brittle and hard to maintain.
 
 ### Jest


### PR DESCRIPTION
Slack discussion: https://cloudfour.slack.com/archives/C03ECJ38E/p1611616301002900

I made a new file: `package-json-script-names.md`, but I don't know where it belongs. The `npm` folder has a README but it is about _publishing_ to npm. Open to suggestions