### PR TITLE
Update editorconfig to use spaces for YAML files

### DIFF
--- a/coding/README.md
+++ b/coding/README.md
@@ -14,6 +14,11 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+# YAML files cannot have tabs
+# @see https://yaml.org/faq.html
+[*.yml]
+indent_style = space
 ```
 
 ### Enforcing editor defaults


### PR DESCRIPTION
YAML files cannot have tabs: https://yaml.org/faq.html

This matters when setting up GitHub workflow files for CI actions. 